### PR TITLE
zur Vermeidung von Hängern: CURLOPT_TTIMEOUT setzen

### DIFF
--- a/BMW/module.php
+++ b/BMW/module.php
@@ -576,6 +576,7 @@ class BMWConnectedDrive extends IPSModule
         curl_setopt($ch, CURLOPT_URL, $auth_api);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_NOBODY, true);
         curl_setopt($ch, CURLOPT_COOKIESESSION, true);
@@ -1606,6 +1607,7 @@ class BMWConnectedDrive extends IPSModule
 
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 
         $response = curl_exec($ch);
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/BMW/module.php
+++ b/BMW/module.php
@@ -576,7 +576,7 @@ class BMWConnectedDrive extends IPSModule
         curl_setopt($ch, CURLOPT_URL, $auth_api);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_HEADER, true);
         curl_setopt($ch, CURLOPT_NOBODY, true);
         curl_setopt($ch, CURLOPT_COOKIESESSION, true);
@@ -1607,7 +1607,7 @@ class BMWConnectedDrive extends IPSModule
 
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 
         $response = curl_exec($ch);
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
Zur Vermeidung von Hängern bei der Kommunikation mit BMW wird nun auch CURLOPT_TTIMEOUT auf 30s gesetzt