### PR TITLE
additional status "NOT_EXECUTED"

### DIFF
--- a/BMW/locale.json
+++ b/BMW/locale.json
@@ -133,6 +133,7 @@
 			"pending": "ausstehend",
 			"initated": "initiiert",
 			"executed": "ausgeführt",
+			"not_executed": "nicht ausgeführt",
 			"failed": "fehlgeschlagen",
 			"error": "fehlgeschlagen",
 			"cancelled": "abgebrochen",

--- a/BMW/module.php
+++ b/BMW/module.php
@@ -1220,6 +1220,7 @@ class BMWConnectedDrive extends IPSModule
             'ERROR'     => 'error',
             'CANCELLED' => 'cancelled',
             'EXECUTED'  => 'executed',
+            'NOT_EXECUTED'  => 'not_executed',
         ];
         $client = [
             'PORTAL'      => 'Web-Portal',


### PR DESCRIPTION
Hi Fonzo,
ich habe immer einen Eintrag im Meldungsfenster, da es diesen Status nicht gibt.
Ursache ist, dass die Standheizung nicht aktiviert werden konnte, da der Tank leer war.

BR
Attain
![grafik](https://user-images.githubusercontent.com/35669489/111873110-0446a780-898f-11eb-9787-1a237aba99f4.png)
